### PR TITLE
Update a broken link

### DIFF
--- a/docs/appendix-b.md
+++ b/docs/appendix-b.md
@@ -1,6 +1,6 @@
 ## Appendix B: Sample Quality Assessment Surveillance Plan (QASP)
 
-Per [the "Require demos, not memos" best practice](#require-demos-not-memos), here is a sample QASP, which should be incorporated into agile software RFPs.
+Per [the "Require demos, not memos" best practice](https://agilebudgeting.org/plays/demos/), here is a sample QASP, which should be incorporated into agile software RFPs.
 
 | **Deliverable** | **Performance Standard(s)** | **Acceptable Quality Level** | **Method of Assessment** |
 | --- | --- | --- | --- |


### PR DESCRIPTION
The link to the best practice where this was derived from ended up being an internal reference that I presume existed prior to the transfer of this content to this webpage. Updated the link to the current home of the play being referenced.